### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/4201104034/0d460566-ab2a-45d2-a0f7-fbd33ba82c35/58aa67b3-87e9-4f63-946d-0ce6cdc21cec/_apis/work/boardbadge/ca08890e-ddba-4dd6-b4ed-446d565369df)](https://dev.azure.com/4201104034/0d460566-ab2a-45d2-a0f7-fbd33ba82c35/_boards/board/t/58aa67b3-87e9-4f63-946d-0ce6cdc21cec/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.